### PR TITLE
Add env var to add prefix for HTTP endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ Or with docker:
 docker run -p 9222:9222 caarlos0/domain_exporter
 ```
 
+#### Environment variables
+
+- `DOMAIN_EXPORTER_URL_PREFIX` - use when HTTP endpoint served with a prefix, e.g.:
+
+  For this endpoint `http://example.org/exporters/domains` set to `/exporters/domains`.
+
+  Not really required since useful only to prevent breaking human-oriented links.
+
+  Defaults to empty string.
+
 ## Configuration
 
 On the prometheus settings, add the domain_exporter prober:

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/alecthomas/kingpin"
@@ -27,6 +28,11 @@ func main() {
 	kingpin.HelpFlag.Short('h')
 	kingpin.Parse()
 
+	urlPrefix, urlPrefixOK := os.LookupEnv("DOMAIN_EXPORTER_URL_PREFIX")
+	if !urlPrefixOK {
+		urlPrefix = ""
+	}
+
 	if *debug {
 		_ = log.Base().SetLevel("debug")
 		log.Debug("enabled debug mode")
@@ -45,11 +51,11 @@ func main() {
 			<head><title>Domain Exporter</title></head>
 			<body>
 				<h1>Domain Exporter</h1>
-				<p><a href="/metrics">Metrics</a></p>
-				<p><a href="/probe?target=google.com">probe google.com</a></p>
+				<p><a href="%[1]s/metrics">Metrics</a></p>
+				<p><a href="%[1]s/probe?target=google.com">probe google.com</a></p>
 			</body>
 			</html>
-			`,
+			`, urlPrefix,
 		)
 	})
 	log.Info("listening on", *bind)


### PR DESCRIPTION
This needed to be able to work both via dedicated HTTP resource and
prefixed one.